### PR TITLE
docs: import AGENTS.md for Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
 # Repository Guidelines
 
-> **📚 Note**: This file provides high-level repository guidelines. For detailed HealthRAG-specific development guidance, architecture, and current phase status, see [`CLAUDE.md`](CLAUDE.md). All agents must also follow the universal rules in [`../AGENTS.md`](../AGENTS.md) and [`../CLAUDE.md`](../CLAUDE.md).
+> **📚 Note**: This file is the canonical repository contract. For detailed
+> HealthRAG-specific development guidance, architecture, and current phase
+> status, see [`CLAUDE.md`](CLAUDE.md). Claude Code imports this file from the
+> root `CLAUDE.md`; user-level agent instructions still apply normally.
 
 ## Project Structure & Module Organization
 Primary application logic lives in `src/`, with `main.py` driving the Streamlit UI, `rag_system.py` orchestrating retrieval, and specialist modules (e.g., `workout_coach.py`, `food_logger.py`) encapsulating domain features. Configuration defaults sit in `config/settings.py`. Persisted assets belong under `data/`: PDFs in `data/pdfs/`, embeddings in `data/vectorstore/`, and sample artifacts in `src/data/`. Add developer-facing notes to `docs/` so operational guidance stays centralized.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,15 @@
+@AGENTS.md
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## 📚 Documentation Structure
 
-This file is part of a hierarchy of agent guidance documents:
-
-1. **Parent Level (applies to ALL JLWAI projects):**
-   - [`../AGENTS.md`](../AGENTS.md) - Universal agent contract (branch rules, iteration loop, test-first principles)
-   - [`../CLAUDE.md`](../CLAUDE.md) - Parent-level rules (branch enforcement hooks, workflow)
-
-2. **Project Level (HealthRAG-specific):**
-   - **`CLAUDE.md`** (this file) - Detailed HealthRAG development guidance
-   - [`AGENTS.md`](AGENTS.md) - Repository guidelines (build commands, coding style, testing)
-
-**All agents must read BOTH parent and project-level documentation.**
+- [`AGENTS.md`](AGENTS.md) is the canonical repository contract and is imported
+  above for Claude Code.
+- **`CLAUDE.md`** (this file) adds Claude-specific HealthRAG guidance.
+- User-level agent instructions continue to apply normally.
 
 ## Project Context
 


### PR DESCRIPTION
## Summary

- import the canonical root `AGENTS.md` from `CLAUDE.md`
- remove broken parent instruction links that do not exist in a standalone clone
- preserve Claude-specific guidance below the import

**Expected Outcomes** (Binary, Testable):

- [x] Root `CLAUDE.md` begins with `@AGENTS.md`.
- [x] Root `AGENTS.md` remains readable and canonical.
- [x] Standalone-clone instructions contain no broken parent `AGENTS.md` or `CLAUDE.md` links.
- [x] Claude-specific HealthRAG guidance remains below the import.
- [x] The exact head merges cleanly into current `main`.

## Review Evidence

- `test "$(sed -n '1p' CLAUDE.md)" = '@AGENTS.md'` — PASS
- `test -r AGENTS.md` — PASS
- parent-link grep — PASS
- `git diff --check` — PASS
- exact-diff Gitleaks scan — PASS, no new leaks
- `git merge-tree --write-tree origin/main pr35` — PASS
- Exact reviewed head: `ad6152f98af024fbb6829226229e214a4acbad96`

The full legacy tree still has 17 unrelated Gitleaks findings; this two-file exact diff adds none.

Tracks jasonewillis/jwHomeLab#56.
